### PR TITLE
fix: destroy hanging sockets and prevent crash on Windows

### DIFF
--- a/src/server/DevServer.ts
+++ b/src/server/DevServer.ts
@@ -69,9 +69,11 @@ export class DevServer extends BaseDevServer {
       },
     });
 
-    this.hmrServer = new WebSocketHMRServer(this.fastify, {
-      compiler: this.compiler,
-    });
+    this.hmrServer = this.wsRouter.registerServer(
+      new WebSocketHMRServer(this.fastify, {
+        compiler: this.compiler,
+      })
+    );
 
     this.symbolicator = new Symbolicator(
       this.compiler.context,

--- a/src/server/ws/WebSocketRouter.ts
+++ b/src/server/ws/WebSocketRouter.ts
@@ -1,0 +1,55 @@
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { FastifyDevServer } from '../types';
+import { WebSocketServer } from './WebSocketServer';
+
+/**
+ * TODO
+ *
+ * @category Development server
+ */
+export class WebSocketRouter {
+  /** TODO */
+  protected servers: WebSocketServer[] = [];
+
+  /**
+   * TODO
+   *
+   * @param fastify
+   * @param options
+   */
+  constructor(private fastify: FastifyDevServer) {
+    this.fastify.server.on(
+      'upgrade',
+      (request: IncomingMessage, socket: Socket, head: Buffer) => {
+        const { pathname } = new URL(request.url || '', 'http://localhost');
+        let matched = false;
+        for (const server of this.servers) {
+          if (server.shouldUpgrade(pathname)) {
+            matched = true;
+            server.upgrade(request, socket, head);
+            break;
+          }
+        }
+
+        if (!matched) {
+          this.fastify.log.debug({
+            msg: 'Destroying socket connection as no server was matched',
+            pathname,
+          });
+          socket.destroy();
+        }
+      }
+    );
+  }
+
+  /**
+   * TODO
+   *
+   * @param server
+   */
+  registerServer<T extends WebSocketServer>(server: T): T {
+    this.servers.push(server);
+    return server;
+  }
+}

--- a/src/server/ws/WebSocketRouter.ts
+++ b/src/server/ws/WebSocketRouter.ts
@@ -4,19 +4,24 @@ import { FastifyDevServer } from '../types';
 import { WebSocketServer } from './WebSocketServer';
 
 /**
- * TODO
+ * Class for creating a WebSocket router to forward connections to the
+ * respective {@link WebSocketServer} as long as the connection is accepted for the upgrade by the
+ * server.
+ *
+ * If the connection is not accepted by any `WebSocketServer`, it will be destroyed to avoid
+ * creating handling connections and potentially throwing `ECONNRESET` errors.
  *
  * @category Development server
  */
 export class WebSocketRouter {
-  /** TODO */
+  /** The list of all register WebSocket servers. */
   protected servers: WebSocketServer[] = [];
 
   /**
-   * TODO
+   * Create new instance of `WebSocketRouter` and attach it to the given Fastify instance.
+   * Any logging information, will be passed through standard `fastify.log` API.
    *
-   * @param fastify
-   * @param options
+   * @param fastify Fastify instance to attach the WebSocket router to.
    */
   constructor(private fastify: FastifyDevServer) {
     this.fastify.server.on(
@@ -44,9 +49,11 @@ export class WebSocketRouter {
   }
 
   /**
-   * TODO
+   * Register a new {@link WebSocketServer}. New connection will now
+   * check if the given server will accept them and forward them.
    *
-   * @param server
+   * @param server WebSocket server to register.
+   * @returns The same instance of the WebSocket server after it's been registered.
    */
   registerServer<T extends WebSocketServer>(server: T): T {
     this.servers.push(server);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Change the way the development server handles multiple WebSocket servers by adding a dedicated router, which allows to properly close all incoming connections that were not accepted by any WebSocket server. This prevent handling socket issue which (especially on Windows) can crash the process with `ECONNRESET` error.

### Test plan

1. Configure RNWT for React Native Windows.
2. Run `webpack-start` command.
2. Open React Native Windows application and load the bundle.
3. Wait for at least 30s.
4. App should not crash and the HMR should still work.
