### PR TITLE
Add .json to resolver

### DIFF
--- a/src/webpack/utils/getResolveOptions.ts
+++ b/src/webpack/utils/getResolveOptions.ts
@@ -29,6 +29,7 @@ export function getResolveOptions(platform: string) {
       '.js',
       '.tsx',
       '.jsx',
+      '.json',
     ],
   };
 }


### PR DESCRIPTION
### Summary

We have some modules that import `.json` files without extension that fail when using this toolkit. The `.json` extension is included in the default webpack resolver settings, and work with metro so it makes sense for it to be included here too. 
