### PR TITLE
chore: rename project due to trademark issues

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes the high-level architecture of `react-native-webpack-toolkit`.
+This document describes the high-level architecture of `@callstack/nativepack`.
 If you want to familiarize yourself with the code base, you are just in the right place!
 
 Before you start, make sure you've gone through the [README](./README.md).
@@ -10,18 +10,18 @@ for an additional context on configuration, parameters and types.
 
 ## General overview
 
-There are 2 ways to look at the content of the `react-native-webpack-toolkit`:
+There are 2 ways to look at the content of the `@callstack/nativepack`:
 
 - by command that are exposed to React Native CLI
 - by Webpack plugins and utilities
 
 Here's a chart that represents both aspect of the codebase:
 
-![Overview of react-native-webpack-toolkit codebase](./overview.png)
+![Overview of @callstack/nativepack codebase](./overview.png)
 
 ## Structure
 
-The following list describes the components that create `react-native-webpack-toolkit`:
+The following list describes the components that create `@callstack/nativepack`:
 
 - `public/` — Public assets for Debugger UI.
 - `templates/` — Templates for files to initialize a new project.
@@ -76,7 +76,7 @@ Check [`parseCliOptions` section](#parseclioptions) for details on configuration
 
 ## `parseCliOptions`
 
-To support the common use-case, which is to run `react-native-webpack-toolkit` using
+To support the common use-case, which is to run `@callstack/nativepack` using
 React Native CLI, we need to be able to pass CLI options passed to the command (eg: when running
 `npx react-native webpack-start`) to the Webpack configuration. The problem is, that Webpack configuration
 must be an object with all the required fields already filled in.
@@ -105,14 +105,14 @@ values directly into Webpack configuration file or read it from somewhere else (
   
 ## Logging
 
-Depending on how you run `react-native-webpack-toolkit` the logging works slightly differently, but
+Depending on how you run `@callstack/nativepack` the logging works slightly differently, but
 the end destination for all logs is `Reporter` instance — this is the place where all logs are
 written to the terminal and/or file. The route that each log takes to get to the reporter instance
 will differ.
 
 The top-level `Reporter` instance will also try to broadcast logs to the connected Flipper instance
 under _React Native_ -> _Logs_ with tag `rnwt_<type>` where `type` can be `debug`, `info`, `warn`
-or `error`. Because of the Flipper tight integration with Metro all `react-native-webpack-toolkit`
+or `error`. Because of the Flipper tight integration with Metro all `@callstack/nativepack`
 logs will be reported as `verbose` so make sure you sent the filter to include type `Verbose`
 and use searching to filter logs e.g. by typing `rnwt_debug`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `react-native-webpack-toolkit`
+# Contributing to `@callstack/nativepack`
 
 ## Code of Conduct
 
@@ -65,8 +65,8 @@ NOTE: You must have a `GITHUB_TOKEN` environment variable available. You can cre
 
 ## Reporting issues
 
-You can report issues on our [bug tracker](https://github.com/callstack/react-native-webpack-toolkit/issues). Please follow the issue template when opening an issue.
+You can report issues on our [bug tracker](https://github.com/callstack/nativepack/issues). Please follow the issue template when opening an issue.
 
 ## License
 
-By contributing to `react-native-webpack-toolkit`, you agree that your contributions will be licensed under its **MIT** license.
+By contributing to `@callstack/nativepack`, you agree that your contributions will be licensed under its **MIT** license.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">react-native-webpack-toolkit</h1>
+<h1 align="center">@callstack/nativepack</h1>
 <p align="center">
 A Webpack-based toolkit to build your React Native application with full support of Webpack ecosystem.
 </p>
@@ -18,9 +18,9 @@ A Webpack-based toolkit to build your React Native application with full support
 [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 [![Code of Conduct][coc-badge]][coc]
 
-`react-native-webpack-toolkit` is a next generation of [Haul](https://github.com/callstack/haul) — a Webpack-based bundler for React Native applications.
+`@callstack/nativepack` is a next generation of [Haul](https://github.com/callstack/haul) — a Webpack-based bundler for React Native applications.
 
-`react-native-webpack-toolkit` uses Webpack 5 and React Native CLI's plugin system to allow you to bundle your application using Webpack and allow to easily switch from Metro.
+`@callstack/nativepack` uses Webpack 5 and React Native CLI's plugin system to allow you to bundle your application using Webpack and allow to easily switch from Metro.
 
 __Check the base [`webpack.config.js`](./templates/webpack.config.js) template, if you're curious how it all looks like.__
 
@@ -63,55 +63,55 @@ __Check the base [`webpack.config.js`](./templates/webpack.config.js) template, 
 
 ## Why & when
 
-The main feature of `react-native-webpack-toolkit` is Webpack and its ecosystem of loaders, plugins and support for various features like symlinks, aliases etc. However, because `react-native-webpack-toolkit` is based on Webpack, it is targeted towards advanced users who already know how to use Webpack and want to leverage Webpack ecosystem.
+The main feature of `@callstack/nativepack` is Webpack and its ecosystem of loaders, plugins and support for various features like symlinks, aliases etc. However, because `@callstack/nativepack` is based on Webpack, it is targeted towards advanced users who already know how to use Webpack and want to leverage Webpack ecosystem.
 
 If you're just starting with React Native, it's better to stick with the default solution — Metro, since you probably won't benefit much from switching to Webpack.
 
 ## Design goals
 
-1. `react-native-webpack-toolkit` was design for the advanced users, as such it exposes _low-level API_ in form of Webpack plugins and utilities, meaning we only give you the tools you need to build React Native application, but the actual configuration and maintenance of said config is on your shoulders.
-2. To support wide variety of use cases and give you as much control as possible, `react-native-webpack-toolkit` is written to allow you to bundle and run development server directly from Webpack CLI as well by using React Native CLI. You can pick one you want to go with.
-3. Based on our experience with [Haul](https://github.com/callstack/haul), we shift as much responsibility onto you as possible, so that we can develop features, move at reasonable pace and reduce maintenance cost. Therefor, `react-native-webpack-toolkit` should be used by seasoned React Native developers with at least basic experience with Webpack.
-4. __[Future]__ We plan to use `react-native-webpack-toolkit` as a foundation for bringing multi-bundle support to React Native, by allowing you to use asynchronous chunks and finally Webpack 5 latest feature — [Module Federation](https://medium.com/swlh/webpack-5-module-federation-a-game-changer-to-javascript-architecture-bcdd30e02669).
+1. `@callstack/nativepack` was design for the advanced users, as such it exposes _low-level API_ in form of Webpack plugins and utilities, meaning we only give you the tools you need to build React Native application, but the actual configuration and maintenance of said config is on your shoulders.
+2. To support wide variety of use cases and give you as much control as possible, `@callstack/nativepack` is written to allow you to bundle and run development server directly from Webpack CLI as well by using React Native CLI. You can pick one you want to go with.
+3. Based on our experience with [Haul](https://github.com/callstack/haul), we shift as much responsibility onto you as possible, so that we can develop features, move at reasonable pace and reduce maintenance cost. Therefor, `@callstack/nativepack` should be used by seasoned React Native developers with at least basic experience with Webpack.
+4. __[Future]__ We plan to use `@callstack/nativepack` as a foundation for bringing multi-bundle support to React Native, by allowing you to use asynchronous chunks and finally Webpack 5 latest feature — [Module Federation](https://medium.com/swlh/webpack-5-module-federation-a-game-changer-to-javascript-architecture-bcdd30e02669).
 
 
-## `react-native-webpack-toolkit` vs Metro
+## `@callstack/nativepack` vs Metro
 
-Both Metro and `react-native-webpack-toolkit` have different approaches for the similar problem — bundling JavaScript code for your React Native application, where Metro is custom-built solution and `react-native-webpack-toolkit` uses Webpack. As a result there few differences that you should consider when deciding the solution to use:
+Both Metro and `@callstack/nativepack` have different approaches for the similar problem — bundling JavaScript code for your React Native application, where Metro is custom-built solution and `@callstack/nativepack` uses Webpack. As a result there few differences that you should consider when deciding the solution to use:
 
 - Metro is slightly faster, since it has less overhead compared to Webpack, and it's configuration options, plugin and loader system.
 - Webpack configuration options and ecosystem allows for much greater control and support for advanced use-cases.
-- Metro's Fast Refresh is slightly more flexible compared to Webpack's solution: Hot Module Replacement + React Refresh — some cases require full application reloaded with `react-native-webpack-toolkit`, but they are supported with Metro See: [Known issues](#known-issues).
+- Metro's Fast Refresh is slightly more flexible compared to Webpack's solution: Hot Module Replacement + React Refresh — some cases require full application reloaded with `@callstack/nativepack`, but they are supported with Metro See: [Known issues](#known-issues).
 
-## `react-native-webpack-toolkit` vs Haul
+## `@callstack/nativepack` vs Haul
 
-`react-native-webpack-toolkit` is a direct successor to [Haul](https://github.com/callstack/haul). Therefore we took the experience we gained with Haul while making rather major changes in the approach:
+`@callstack/nativepack` is a direct successor to [Haul](https://github.com/callstack/haul). Therefore we took the experience we gained with Haul while making rather major changes in the approach:
 
-- `react-native-webpack-toolkit` has smaller footprint and allows for greater level of customization, since you have access to the Webpack config.
-- `react-native-webpack-toolkit` supports Hot Module Replacement + React Refresh, whereas Haul does not.
-- `react-native-webpack-toolkit` doesn't support any kind of multi-bundling __yet__, whereas Haul supports legacy implementation of multi-bundling (though it requires to alter React Native source code, so we don't recommend that).
-- `react-native-webpack-toolkit` delivers better Developer Experience by providing you with more meaningful logs, easier usage and more customizability.
+- `@callstack/nativepack` has smaller footprint and allows for greater level of customization, since you have access to the Webpack config.
+- `@callstack/nativepack` supports Hot Module Replacement + React Refresh, whereas Haul does not.
+- `@callstack/nativepack` doesn't support any kind of multi-bundling __yet__, whereas Haul supports legacy implementation of multi-bundling (though it requires to alter React Native source code, so we don't recommend that).
+- `@callstack/nativepack` delivers better Developer Experience by providing you with more meaningful logs, easier usage and more customizability.
 
 ## Installation & setup
 
 ### Compatibility with Webpack
 
-On paper, `react-native-webpack-toolkit` should work with any version of Webpack 5, but we recommend to consult with the compatibility table below.
-The table represents versions of `webpack` for which `react-native-webpack-toolkit` is confirmed to work correctly.
+On paper, `@callstack/nativepack` should work with any version of Webpack 5, but we recommend to consult with the compatibility table below.
+The table represents versions of `webpack` for which `@callstack/nativepack` is confirmed to work correctly.
 
 If you don't see your version, give it a go. If it doesn't work, please open an issue.
 
-| `webpack`  | `react-native-webpack-toolkit` |
-| ---------- | ------------------------------ |
-| `5.22.0`   | `1.0.x`, `1.1.x`, `1.2.x`      |
-| `>=5.29.0` | `1.2.x`,                       |
+| `webpack`  | `@callstack/nativepack`   |
+| ---------- | ------------------------- |
+| `5.22.0`   | `1.0.x`, `1.1.x`, `1.2.x` |
+| `>=5.29.0` | `1.2.x`,                  |
 
 1. Install necessary dependencies:
 
 ```bash
-npm i -D webpack terser-webpack-plugin babel-loader react-native-webpack-toolkit
+npm i -D webpack terser-webpack-plugin babel-loader @callstack/nativepack
 # or
-yarn add -D webpack terser-webpack-plugin babel-loader react-native-webpack-toolkit
+yarn add -D webpack terser-webpack-plugin babel-loader @callstack/nativepack
 ```
 
 2. Create `webpack.config.js` based on the [template](./templates/webpack.config.js).
@@ -155,7 +155,7 @@ final application file (`ipa`/`apk`). Chunks can help you improve startup time b
 from being both parsed and evaluated at the start of the app. The chunks code will still be included in the file,
 so the total download size the user will have to download from App Store/Google Play will not shrink.
 
-Asynchronous chunks support requires `react-native-webpack-toolkit` native module to be included in the app
+Asynchronous chunks support requires `@callstack/nativepack` native module to be included in the app
 to download/read and evaluate JavaScript code from chunks. By default, the native module should be auto-linked
 so there's no additional steps for you to perform. The template [`webpack.config.js`](./templates/webpack.config.js)
 is configured to support asynchronous chunks as well. 
@@ -223,7 +223,7 @@ and reproduce the error or `console.log`/`console.error` call.
 
 ## Made with ❤️ at Callstack
 
-`react-native-webpack-toolkit` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+`@callstack/nativepack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
 
 <!-- badges -->
 [callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=react-native-paper&utm_term=readme-with-love
@@ -232,20 +232,20 @@ and reproduce the error or `console.log`/`console.error` call.
 [goto-usage-badge]: https://img.shields.io/badge/go%20to-Usage-blue?style=flat-square
 [goto-usage]: #usage
 [goto-api-docs-badge]: https://img.shields.io/badge/go%20to-API%20docs-blue?style=flat-square
-[goto-api-docs]: https://react-native-webpack-toolkit.netlify.app/
+[goto-api-docs]: https://@callstack/nativepack.netlify.app/
 
 [goto-contributing-badge]: https://img.shields.io/badge/go%20to-CONTRIBUTING.md-blue?style=flat-square
 [goto-contributing]: ./CONTRIBUTING.md
 [goto-architecture-badge]: https://img.shields.io/badge/go%20to-ARCHITECTURE.md-blue?style=flat-square
 [goto-architecture]: ./ARCHITECTURE.md
 
-[build-badge]: https://img.shields.io/github/workflow/status/callstack/react-native-webpack-toolkit/CI/main?style=flat-square
-[build]: https://github.com/callstack/react-native-webpack-toolkit/actions/workflows/main.yml
-[version-badge]: https://img.shields.io/npm/v/react-native-webpack-toolkit?style=flat-square
-[version]: https://www.npmjs.com/package/react-native-webpack-toolkit
-[license-badge]: https://img.shields.io/npm/l/react-native-webpack-toolkit.svg?style=flat-square
-[license]: https://github.com/callstack/react-native-webpack-toolkit/blob/master/LICENSE
+[build-badge]: https://img.shields.io/github/workflow/status/callstack/@callstack/nativepack/CI/main?style=flat-square
+[build]: https://github.com/callstack/@callstack/nativepack/actions/workflows/main.yml
+[version-badge]: https://img.shields.io/npm/v/@callstack/nativepack?style=flat-square
+[version]: https://www.npmjs.com/package/@callstack/nativepack
+[license-badge]: https://img.shields.io/npm/l/@callstack/nativepack.svg?style=flat-square
+[license]: https://github.com/callstack/@callstack/nativepack/blob/master/LICENSE
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [prs-welcome]: ./CONTRIBUTING.md
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
-[coc]: https://github.com/callstack/react-native-webpack-toolkit/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/callstack/@callstack/nativepack/blob/master/CODE_OF_CONDUCT.md

--- a/examples/TesterApp/ios/Podfile
+++ b/examples/TesterApp/ios/Podfile
@@ -12,7 +12,7 @@ target 'TesterApp' do
     :hermes_enabled => true
   )
 
-  pod 'react-native-webpack-toolkit', :path => '../../..'
+  pod '@callstack/nativepack', :path => '../../..'
 
   target 'TesterAppTests' do
     inherit! :complete

--- a/examples/TesterApp/ios/Podfile.lock
+++ b/examples/TesterApp/ios/Podfile.lock
@@ -268,7 +268,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
   - React-jsinspector (0.64.0)
-  - react-native-webpack-toolkit (1.0.0-3):
+  - @callstack/nativepack (1.0.0-3):
     - React-Core
   - React-perflogger (0.64.0)
   - React-RCTActionSheet (0.64.0):
@@ -378,7 +378,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - react-native-webpack-toolkit (from `../../..`)
+  - @callstack/nativepack (from `../../..`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -440,7 +440,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
-  react-native-webpack-toolkit:
+  @callstack/nativepack:
     :path: "../../.."
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
@@ -497,7 +497,7 @@ SPEC CHECKSUMS:
   React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
   React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
   React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
-  react-native-webpack-toolkit: f3e41ac2f1ff494538b4e5a7ab41d9fb7b755e1b
+  @callstack/nativepack: f3e41ac2f1ff494538b4e5a7ab41d9fb7b755e1b
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f

--- a/examples/TesterApp/webpack.config.js
+++ b/examples/TesterApp/webpack.config.js
@@ -15,10 +15,10 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
- * https://github.com/callstack/react-native-webpack-toolkit/blob/main/README.md
+ * https://github.com/callstack/@callstack/nativepack/blob/main/README.md
  *
  * The API documentation for the functions and plugins used in this file is available at:
- * https://react-native-webpack-toolkit.netlify.app/
+ * https://@callstack/nativepack.netlify.app/
  */
 
 /**

--- a/nativepack.podspec
+++ b/nativepack.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-webpack-toolkit"
+  s.name         = "@callstack/nativepack"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "10.0" }
-  s.source       = { :git => "https://github.com/callstack/react-native-webpack-toolkit.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/callstack/nativepack.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "@callstack/nativepack",
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-webpack-toolkit",
+  "name": "@callstack/nativepack",
   "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "engines": {
     "node": ">=12.x"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clean": "del dist",
     "prepare": "npm run build && npm run prepare:website",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-webpack-toolkit",
+  "name": "@callstack/nativepack",
   "version": "1.3.0",
   "description": "A Webpack-based toolkit to build your React Native application with full support of Webpack ecosystem.",
   "main": "dist/index.js",
@@ -11,12 +11,12 @@
     "android",
     "ios",
     "react-native.config.js",
-    "react-native-webpack-toolkit.podspec",
+    "nativepack.podspec",
     "!android/build",
     "!ios/build"
   ],
-  "homepage": "https://github.com/callstack/react-native-webpack-toolkit",
-  "repository": "github:callstack/react-native-webpack-toolkit",
+  "homepage": "https://github.com/callstack/nativepack",
+  "repository": "github:callstack/nativepack",
   "keywords": [
     "react-native",
     "react native",
@@ -41,7 +41,7 @@
     "tsc:watch": "npm run tsc:build -- --watch --preserveWatchOutput",
     "webpack": "webpack -c webpack.config.js",
     "webpack:watch": "npm run webpack -- --watch",
-    "copy:watch": "sleep 5 && npx cpx --watch \"dist/**\" examples/TesterApp/node_modules/react-native-webpack-toolkit",
+    "copy:watch": "sleep 5 && npx cpx --watch \"dist/**\" examples/TesterApp/node_modules/@callstack/nativepack",
     "build": "npm run clean && npm run babel && npm run tsc && npm run webpack",
     "build:watch": "npm run clean && concurrently npm:babel:watch npm:tsc:watch npm:webpack:watch",
     "release": "release-it",

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -10,12 +10,12 @@ const {
   ReactNativeTargetPlugin,
   getPublicPath,
   getChunkFilename,
-} = require('react-native-webpack-toolkit');
+} = require('@callstack/nativepack');
 const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
- * https://github.com/callstack/react-native-webpack-toolkit/blob/main/README.md
+ * https://github.com/callstack/nativepack/blob/main/README.md
  *
  * The API documentation for the functions and plugins used in this file is available at:
  * https://react-native-webpack-toolkit.netlify.app/

--- a/website/components/Layout.tsx
+++ b/website/components/Layout.tsx
@@ -15,7 +15,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="A Webpack-based toolkit to build your React Native application with full support of Webpack ecosystem."
         />
 
-        <meta name="og:title" content="react-native-webpack-toolkit" />
+        <meta name="og:title" content="@callstack/nativepack" />
         {/* <meta name="twitter:card" content="summary_large_image" /> */}
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
@@ -31,7 +31,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <div className="container m-auto max-w-screen-xl px-8 py-4 flex flex-col md:flex-row justify-between">
           <NextLink href="/">
             <a className="text-2xl tracking-wide font-bold">
-              react-native-webpack-toolkit
+              @callstack/nativepack
             </a>
           </NextLink>
           <div className="text-xs flex items-center mt-8 md:mt-0">
@@ -41,7 +41,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               </a>
             </NextLink>
             <a
-              href="https://github.com/callstack/react-native-webpack-toolkit"
+              href="https://github.com/callstack/@callstack/nativepack"
               className="transition ease-in duration-200 uppercase rounded-full text-cool-gray-400 hover:text-cool-gray-300 ml-2"
               target="_blank"
               rel="noreferrer"
@@ -75,7 +75,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           </div>
           <div>
             <Link
-              href="https://github.com/callstack/react-native-webpack-toolkit"
+              href="https://github.com/callstack/@callstack/nativepack"
               external
               bold
             >

--- a/website/pages/docs/api/[type]/[id].tsx
+++ b/website/pages/docs/api/[type]/[id].tsx
@@ -52,7 +52,7 @@ export default function ReflectionPage({
   return (
     <Layout>
       <Head>
-        <title>{title} | API docs | react-native-webpack-toolkit</title>
+        <title>{title} | API docs | @callstack/nativepack</title>
       </Head>
       <Link href="/docs/api" className="ml-8" bold>
         <span className="material-icons mt-0.5">arrow_back</span>

--- a/website/pages/docs/api/index.tsx
+++ b/website/pages/docs/api/index.tsx
@@ -16,7 +16,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
       md: html
-        .replace(/<h1>react-native-webpack-toolkit<\/h1>/, '')
+        .replace(/<h1>@callstack\/nativepack<\/h1>/, '')
         .replace(/<h3>/, '<h2>')
         .replace(/<\/h3>/, '</h2>')
         .replace(/<h2>/, '<h1>')
@@ -29,7 +29,7 @@ export default function ApiDocs({ md }: { md: string }) {
   return (
     <Layout>
       <Head>
-        <title>API docs | react-native-webpack-toolkit</title>
+        <title>API docs | @callstack/nativepack</title>
       </Head>
       <div className="overflow-x-auto">
         <Markdown source={md} />

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
   return (
     <Layout>
       <Head>
-        <title>react-native-webpack-toolkit</title>
+        <title>@callstack/nativepack</title>
       </Head>
       <div className="px-4">
         <h1 className="text-center text-3xl italic tracking-wide xl:px-80">
@@ -36,7 +36,7 @@ export default function Home() {
         </h1>
         <div className="flex flex-col sm:flex-row sm:justify-center mt-8">
           <a
-            href="https://github.com/callstack/react-native-webpack-toolkit#react-native-webpack-toolkit"
+            href="https://github.com/callstack/@callstack/nativepack#@callstack/nativepack"
             className="inline-flex items-center my-2 mx-2 px-3 py-2 transition ease-in duration-200 rounded-sm font-bold border border-emerald-700 hover:text-cool-gray-200 hover:bg-emerald-600 hover:border-emerald-600"
             target="_blank"
             rel="noreferrer"
@@ -47,7 +47,7 @@ export default function Home() {
             </span>
           </a>
           <a
-            href="https://github.com/callstack/react-native-webpack-toolkit#installation--setup"
+            href="https://github.com/callstack/@callstack/nativepack#installation--setup"
             className="inline-flex items-center my-2 mx-2 px-3 py-2 transition ease-in duration-200 rounded-sm font-bold border border-orange-800 hover:text-cool-gray-200 hover:bg-orange-700 hover:border-orange-700"
             target="_blank"
             rel="noreferrer"
@@ -97,7 +97,7 @@ export default function Home() {
               symnbolication and Remote JavaScript debugging support.
             </div>
             <a
-              href="https://github.com/callstack/react-native-webpack-toolkit#features"
+              href="https://github.com/callstack/@callstack/nativepack#features"
               className="inline-flex items-center mt-6 px-3 py-2 transition ease-in duration-200 rounded-sm font-bold border border-orange-800 hover:text-cool-gray-200 hover:bg-orange-700 hover:border-orange-700"
               target="_blank"
               rel="noreferrer"
@@ -116,7 +116,7 @@ export default function Home() {
               function or manually declaring them inside your Webpack config.
             </div>
             <a
-              href="https://github.com/callstack/react-native-webpack-toolkit#asynchronous-chunks"
+              href="https://github.com/callstack/@callstack/nativepack#asynchronous-chunks"
               className="inline-flex items-center mt-6 px-3 py-2 transition ease-in duration-200 rounded-sm font-bold border border-teal-700 hover:text-cool-gray-200 hover:bg-teal-600 hover:border-teal-600"
               target="_blank"
               rel="noreferrer"
@@ -134,7 +134,7 @@ export default function Home() {
               with React Native.
             </div>
             <a
-              href="https://github.com/callstack/react-native-webpack-toolkit/blob/main/templates/webpack.config.js"
+              href="https://github.com/callstack/@callstack/nativepack/blob/main/templates/webpack.config.js"
               className="inline-flex items-center mt-6 px-3 py-2 transition ease-in duration-200 rounded-sm font-bold border border-violet-900 hover:text-cool-gray-200 hover:bg-violet-700 hover:border-violet-700"
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Rename the project to avoid infringing on a Webpack trademark.

