### PR TITLE
fix: add explicit regex to transpile nativepack to webpack.config.js template

### DIFF
--- a/examples/TesterApp/webpack.config.js
+++ b/examples/TesterApp/webpack.config.js
@@ -180,6 +180,7 @@ module.exports = {
           /node_modules(.*[/\\])+pretty-format/,
           /node_modules(.*[/\\])+metro/,
           /node_modules(.*[/\\])+abort-controller/,
+          /node_modules(.*[/\\])+@callstack\/nativepack/,
         ],
         use: 'babel-loader',
       },

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -180,6 +180,7 @@ module.exports = {
           /node_modules(.*[/\\])+pretty-format/,
           /node_modules(.*[/\\])+metro/,
           /node_modules(.*[/\\])+abort-controller/,
+          /node_modules(.*[/\\])+@callstack\/nativepack/,
         ],
         use: 'babel-loader',
       },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

After the project rename, the existing regexes for transpiling `node_module` dependencies no longer match `@callstack/nativepack`. This PR adds additional regex to `webpack.config.js` to avoid bugs like #27 

### Test plan

1. Run the application.
2. It should not throw unexpected errors.
