### PR TITLE
feat: remote chunks android

### DIFF
--- a/android/src/main/java/com/callstack/nativepack/ChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkLoader.kt
@@ -4,5 +4,6 @@ import com.facebook.react.bridge.Promise
 import java.net.URL
 
 interface ChunkLoader {
-    fun load(url: URL, promise: Promise)
+    fun load(hash: String, id: String, url: URL, promise: Promise)
+    fun preload(hash: String, id: String, url: URL, promise: Promise)
 }

--- a/android/src/main/java/com/callstack/nativepack/ChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkLoader.kt
@@ -1,9 +1,0 @@
-package com.callstack.nativepack
-
-import com.facebook.react.bridge.Promise
-import java.net.URL
-
-interface ChunkLoader {
-    fun load(hash: String, id: String, url: URL, promise: Promise)
-    fun preload(hash: String, id: String, url: URL, promise: Promise)
-}

--- a/android/src/main/java/com/callstack/nativepack/ChunkLoadingError.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkLoadingError.kt
@@ -5,5 +5,7 @@ enum class ChunkLoadingError(val code: String) {
     FileSystemEvalFailure("FileSystemEvalFailure"),
     NetworkFailure("NetworkFailure"),
     RequestFailure("RequestFailure"),
-    RemoteEvalFailure("FileSystemEvalFailure"),
+    RemoteEvalFailure("RemoteEvalFailure"),
+    ChunkInvalidationFailure("ChunkInvalidationFailure"),
+    ChunkCachingFailure("ChunkCachingFailure"),
 }

--- a/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
@@ -3,6 +3,7 @@ package com.callstack.nativepack
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.Promise
 import java.lang.Error
 import java.net.URL

--- a/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
@@ -15,7 +15,7 @@ class ChunkManagerModule(reactContext: ReactApplicationContext) : ReactContextBa
     }
 
     @ReactMethod
-    fun loadChunk(chunkId: String, chunkUrl: String, promise: Promise) {
+    fun loadChunk(chunkHash: String, chunkId: String, chunkUrl: String, promise: Promise) {
         val url = URL(chunkUrl)
 
         // Currently, `loadChunk` supports either `RemoteChunkLoader` or `FileSystemChunkLoader`
@@ -26,14 +26,14 @@ class ChunkManagerModule(reactContext: ReactApplicationContext) : ReactContextBa
                     loader = RemoteChunkLoader(reactApplicationContext)
                 }
 
-                loader?.load(url, promise)
+                loader?.load(chunkHash, chunkId, url, promise)
             }
             url.protocol == "file" -> {
                 if (loader == null) {
                     loader = FileSystemChunkLoader(reactApplicationContext)
                 }
 
-                loader?.load(url, promise)
+                loader?.load(chunkHash, chunkId, url, promise)
             }
             else -> {
                 promise.reject(
@@ -42,5 +42,28 @@ class ChunkManagerModule(reactContext: ReactApplicationContext) : ReactContextBa
                 )
             }
         }
+    }
+
+    fun preloadChunk(chunkHash: String, chunkId: String, chunkUrl: String, promise: Promise) {
+        val url = URL(chunkUrl)
+        when {
+            url.protocol.startsWith("http") -> {
+                if (loader == null) {
+                    loader = RemoteChunkLoader(reactApplicationContext)
+                }
+
+                loader?.preload(chunkHash, chunkId, url, promise)
+            }
+            else -> {
+                promise.reject(
+                        ChunkLoadingError.UnsupportedScheme.code,
+                        "Scheme in URL: '$chunkUrl' is not supported"
+                )
+            }
+        }
+    }
+
+    fun invalidateChunk(chunkHash: String, chunkId: String, chunkUrl: String, promise: Promise) {
+        // TODO: implement me
     }
 }

--- a/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
+++ b/android/src/main/java/com/callstack/nativepack/ChunkManagerModule.kt
@@ -70,8 +70,8 @@ class ChunkManagerModule(reactContext: ReactApplicationContext) : ReactContextBa
                 promise.resolve(null)
             } catch (error: Exception) {
                 promise.reject(
-                        "",
-                        error.message ?: error.toString()
+                        ChunkLoadingError.ChunkInvalidationFailure.code,
+                        "Cannot invalidate some of the chunks"
                 )
             }
         }

--- a/android/src/main/java/com/callstack/nativepack/FileSystemChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/FileSystemChunkLoader.kt
@@ -5,8 +5,12 @@ import com.facebook.react.bridge.ReactContext
 import java.lang.Exception
 import java.net.URL
 
-class FileSystemChunkLoader(private  val reactContext: ReactContext) : ChunkLoader {
-    override fun load(url: URL, promise: Promise) {
+class FileSystemChunkLoader(private val reactContext: ReactContext) : ChunkLoader {
+    override fun preload(hash: String, id: String, url: URL, promise: Promise) {
+        promise.reject("", "Preloading is not supported for a FileSystem chunks")
+    }
+
+    override fun load(hash: String, id: String, url: URL, promise: Promise) {
         try {
             val filename = url.file.split("/").last()
             val assetName = "assets://$filename"

--- a/android/src/main/java/com/callstack/nativepack/FileSystemChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/FileSystemChunkLoader.kt
@@ -5,12 +5,8 @@ import com.facebook.react.bridge.ReactContext
 import java.lang.Exception
 import java.net.URL
 
-class FileSystemChunkLoader(private val reactContext: ReactContext) : ChunkLoader {
-    override fun preload(hash: String, id: String, url: URL, promise: Promise) {
-        promise.reject("", "Preloading is not supported for a FileSystem chunks")
-    }
-
-    override fun load(hash: String, id: String, url: URL, promise: Promise) {
+class FileSystemChunkLoader(private val reactContext: ReactContext) {
+    fun load(hash: String, id: String, url: URL, promise: Promise) {
         try {
             val filename = url.file.split("/").last()
             val assetName = "assets://$filename"

--- a/android/src/main/java/com/callstack/nativepack/RemoteChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/RemoteChunkLoader.kt
@@ -48,7 +48,7 @@ class RemoteChunkLoader(private val reactContext: ReactContext) {
                         onSuccess()
                     } catch (error: Exception) {
                         onError(
-                                ChunkLoadingError.RemoteEvalFailure.code,
+                                ChunkLoadingError.ChunkCachingFailure.code,
                                 error.message ?: error.toString()
                         )
                     }
@@ -77,12 +77,19 @@ class RemoteChunkLoader(private val reactContext: ReactContext) {
     fun load(hash: String, id: String, url: URL, promise: Promise) {
         val path = getChunkFilePath(hash, id)
         downloadAndCache(hash, id, url, {
-            reactContext.catalystInstance.loadScriptFromFile(
-                    "${reactContext.filesDir}/${path}",
-                    url.toString(),
-                    false
-            )
-            promise.resolve(null)
+            try {
+                reactContext.catalystInstance.loadScriptFromFile(
+                        "${reactContext.filesDir}/${path}",
+                        url.toString(),
+                        false
+                )
+                promise.resolve(null)
+            } catch (error: Exception) {
+                promise.reject(
+                        ChunkLoadingError.RemoteEvalFailure.code,
+                        error.message ?: error.toString()
+                )
+            }
         }, { code, message -> promise.reject(code, message) })
     }
 

--- a/android/src/main/java/com/callstack/nativepack/RemoteChunkLoader.kt
+++ b/android/src/main/java/com/callstack/nativepack/RemoteChunkLoader.kt
@@ -9,13 +9,12 @@ import java.io.IOException
 import java.io.OutputStreamWriter
 import java.net.URL
 
-val CHUNKS_DIR = "chunks"
-
 class RemoteChunkLoader(private val reactContext: ReactContext) {
+    private val chunksDirName = "chunks"
     private val client = OkHttpClient()
 
     private fun getChunkFilePath(hash: String, id: String): String {
-        return "${CHUNKS_DIR}/$hash/$id.chunk.bundle"
+        return "${chunksDirName}/$hash/$id.chunk.bundle"
     }
 
     private fun downloadAndCache(hash: String, id: String, url: URL, onSuccess: () -> Unit, onError: (code: String, message: String) -> Unit) {
@@ -33,12 +32,12 @@ class RemoteChunkLoader(private val reactContext: ReactContext) {
             override fun onResponse(call: Call, response: Response) {
                 if (response.isSuccessful) {
                     try {
-                        val chunksDir = File(reactContext.filesDir, CHUNKS_DIR)
+                        val chunksDir = File(reactContext.filesDir, chunksDirName)
                         if (!chunksDir.exists()) {
-                            File(reactContext.filesDir, CHUNKS_DIR).mkdir()
+                            File(reactContext.filesDir, chunksDirName).mkdir()
                         }
 
-                        File(reactContext.filesDir, "${CHUNKS_DIR}/${hash}").mkdir()
+                        File(reactContext.filesDir, "${chunksDirName}/${hash}").mkdir()
                         file.createNewFile()
 
                         val body = response.body?.string()
@@ -88,7 +87,7 @@ class RemoteChunkLoader(private val reactContext: ReactContext) {
     }
 
     fun invalidate(hash: String) {
-        val file = File(reactContext.filesDir, "${CHUNKS_DIR}/${hash}")
+        val file = File(reactContext.filesDir, "${chunksDirName}/${hash}")
 
         if(file.exists()) {
             file.deleteRecursively()
@@ -96,7 +95,7 @@ class RemoteChunkLoader(private val reactContext: ReactContext) {
     }
 
     fun invalidateAll() {
-        val file = File(reactContext.filesDir, CHUNKS_DIR)
+        val file = File(reactContext.filesDir, chunksDirName)
         if(file.exists()) {
             file.deleteRecursively()
         }

--- a/examples/TesterApp/App.js
+++ b/examples/TesterApp/App.js
@@ -26,6 +26,7 @@ import {
 } from 'react-native/Libraries/NewAppScreen';
 
 import { Hello } from './Hello';
+import RemoteChunksSection from './RemoteChunksSection';
 
 const Section = ({children, title}): Node => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -78,6 +79,9 @@ const App: () => Node = () => {
           </Section>
           <Section title="Debug">
             <DebugInstructions />
+          </Section>
+          <Section title="Remote chunks">
+            <RemoteChunksSection />
           </Section>
           <Section title="Learn More">
             Read the docs to discover what to do next:

--- a/examples/TesterApp/Remote.js
+++ b/examples/TesterApp/Remote.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export default function Remote() {
+  return <Text>Remote</Text>;
+}

--- a/examples/TesterApp/RemoteChunksSection.js
+++ b/examples/TesterApp/RemoteChunksSection.js
@@ -33,7 +33,6 @@ const RemoteChunksSection = () => {
       <Button
         title={'Invalidate'}
         onPress={async () => {
-          console.log('!@# Invalidate', ChunkManager.invalidateChunks);
           await ChunkManager.invalidateChunks(['remote']);
           setIsPreloaded(false);
         }}

--- a/examples/TesterApp/RemoteChunksSection.js
+++ b/examples/TesterApp/RemoteChunksSection.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Button, Text } from 'react-native';
+import { ChunkManager } from '../../client';
+
+const Remote = React.lazy(() =>
+  import(/* webpackChunkName: "remote" */ './Remote')
+);
+
+const RemoteChunksSection = () => {
+  const [isPreloaded, setIsPreloaded] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <>
+      {isLoaded ? (
+        <React.Suspense fallback={<Text>Loading...</Text>}>
+          <Remote />
+        </React.Suspense>
+      ) : (
+        <>
+          <Button
+            title={isPreloaded ? 'Preloaded' : 'Preload chunk'}
+            disabled={isPreloaded}
+            onPress={async () => {
+              await ChunkManager.preloadChunk('remote');
+              setIsPreloaded(true);
+            }}
+          />
+
+          <Button title="Load chunk" onPress={() => setIsLoaded(true)} />
+        </>
+      )}
+      <Button
+        title={'Invalidate'}
+        onPress={async () => {
+          console.log('!@# Invalidate', ChunkManager.invalidateChunks);
+          await ChunkManager.invalidateChunks(['remote']);
+          setIsPreloaded(false);
+        }}
+      />
+    </>
+  );
+};
+
+export default RemoteChunksSection;

--- a/examples/TesterApp/babel.config.js
+++ b/examples/TesterApp/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  comments: true,
 };

--- a/examples/TesterApp/index.js
+++ b/examples/TesterApp/index.js
@@ -2,13 +2,16 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './App';
-import {name as appName} from './app.json';
+import { name as appName } from './app.json';
 import { ChunkManager, Chunk } from '../../client';
 
 ChunkManager.configureResolver(async (chunkId) => {
   // chunkId = eg Async_js
+  if (chunkId === 'remote') {
+    return Chunk.fromRemote(`http://localhost:8080/remote_js`);
+  }
   if (__DEV__) {
     return Chunk.fromDevServer(chunkId);
   }

--- a/src/client/chunks-api/ChunkManager.ts
+++ b/src/client/chunks-api/ChunkManager.ts
@@ -61,12 +61,21 @@ class ChunkManager {
     }
   }
 
-  async invalidateChunk(chunkId: string) {
+  async invalidateChunks(chunksIds: string[] = []) {
     try {
-      const url = await this.resolveChunk(chunkId);
-      const chunkHash = this.getChunkHash(url);
-      delete this.resolveCache[chunkId];
-      await NativeModules.ChunkManager.invalidateChunk(chunkHash, chunkId, url);
+      const chunks = await Promise.all(
+        chunksIds.map(async (chunkId) => {
+          const url = await this.resolveChunk(chunkId);
+          const chunkHash = this.getChunkHash(url);
+          delete this.resolveCache[chunkId];
+
+          return {
+            hash: chunkHash,
+          };
+        })
+      );
+
+      await NativeModules.ChunkManager.invalidateChunks(chunks);
     } catch (error) {
       console.error(
         'ChunkManager.preloadChunk invocation failed:',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Android support for remote chunks. Implementation of below methods on NativeModule:
- loadChunk - only improvements
- preloadChunk
- invalidateChunks

### Test plan

I added a Remote section in Tester app where user can test downloading chunk from a remote server. Creating a server with chunk is required in order to do that
