### PR TITLE
Include podspec in release package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "android",
     "ios",
     "commands.js",
-    "nativepack.podspec",
+    "callstack-nativepack.podspec",
     "!android/build",
     "!ios/build"
   ],


### PR DESCRIPTION
#22 introduced a regression in that the podspec was excluded from the release build of the package due to a naming mismatch. 

### Summary

This PR fixes the name in the package whitelist.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
