### PR TITLE
feat: runInBackground thread for iOS

### DIFF
--- a/ios/ChunkManager.mm
+++ b/ios/ChunkManager.mm
@@ -65,11 +65,11 @@ RCT_EXPORT_METHOD(preloadChunk:(nonnull NSString*)chunkId
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 {
-    [self runInBackground:^(){
-        if (!fetch) {
-            // Do nothing, chunk is already preloaded
-            resolve(nil);
-        } else {
+    if (!fetch) {
+        // Do nothing, chunk is already preloaded
+        resolve(nil);
+    } else {
+        [self runInBackground:^(){
             NSURL *chunkUrl = [NSURL URLWithString:chunkUrlString];
             if ([[chunkUrl scheme] hasPrefix:@"http"]) {
                 [self downloadAndCache:chunkId chunkUrl:chunkUrl completionHandler:^(NSError *error) {
@@ -83,8 +83,8 @@ RCT_EXPORT_METHOD(preloadChunk:(nonnull NSString*)chunkId
                 reject(UnsupportedScheme,
                        [NSString stringWithFormat:@"Scheme in URL '%@' is not supported", chunkUrlString], nil);
             }
-        }
-    }];
+        }];
+    }
 }
 
 RCT_EXPORT_METHOD(invalidateChunks:(nonnull NSArray*)chunks


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Added method `runInBackground` which lets to run methods `loadChunk`, `preloadChunk` and `invalidateChunks` without blocking the UI thread for iOS.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Manually test `TesterApp` using 2s delay in methods `loadChunk`, `preloadChunk` and `invalidateChunks`.
The app is responsive hence UI thread is not blocked.

https://user-images.githubusercontent.com/12425395/120200366-b0cdc100-c23d-11eb-8b59-1dc07c7078c3.mov


