### PR TITLE
fix: small windows support fix in babel loader in webpack config

### DIFF
--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -180,7 +180,7 @@ module.exports = {
           /node_modules(.*[/\\])+pretty-format/,
           /node_modules(.*[/\\])+metro/,
           /node_modules(.*[/\\])+abort-controller/,
-          /node_modules(.*[/\\])+@callstack\/nativepack/,
+          /node_modules(.*[/\\])+@callstack[/\\]nativepack/,
         ],
         use: 'babel-loader',
       },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Small regex change on babel loader in webpack to support windows.

### Test plan

n/a
